### PR TITLE
Refactor scheduler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 LABEL maintainer="dgarros@gmail.com"
 
 RUN mkdir /source

--- a/lib/metric_collector/cli.py
+++ b/lib/metric_collector/cli.py
@@ -96,7 +96,7 @@ def main():
     full_parser.add_argument("--logdir", default="logs", help="Directory where to store logs")
     
     full_parser.add_argument("--sharding",  help="Define if the script is part of a shard need to include the place in the shard and the size of the shard [0/3]")
-    full_parser.add_argument("--sharding-offset", default=False, help="Define an offset needs to be applied to the shard_id")
+    full_parser.add_argument("--sharding-offset", default=True, help="Define an offset needs to be applied to the shard_id")
 
     full_parser.add_argument("--parserdir", default="parsers", help="Directory where to find parsers")
     full_parser.add_argument("--timeout", default=600, help="Default Timeout for Netconf session")

--- a/lib/metric_collector/cli.py
+++ b/lib/metric_collector/cli.py
@@ -300,7 +300,7 @@ def main():
 
     if dynamic_args.get('use_scheduler', False):
         device_scheduler = scheduler.Scheduler(
-            shard_id, hosts_manager, parsers_manager,
+            hosts_manager, parsers_manager,
             dynamic_args['output_type'], dynamic_args['output_addr'],
             max_worker_threads=max_worker_threads,
             use_threads=use_threads, num_threads_per_worker=max_collector_threads

--- a/lib/metric_collector/collector.py
+++ b/lib/metric_collector/collector.py
@@ -85,8 +85,8 @@ class Collector:
                 time_end = time.time()
                 time_execution = time_end - time_start
 
-            exec_time_datapoint = [{
-                'measurement': global_measurement_prefix + '_collector_stats',
+            host_time_datapoint = [{
+                'measurement': global_measurement_prefix + '_host_collector_stats',
                 'tags': {
                     'device': dev.hostname,
                     'worker_name': worker_name
@@ -100,8 +100,13 @@ class Collector:
                     'unreacheable': int(not host_reachable)
                 }
             }]
+            if os.environ.get('NOMAD_JOB_NAME'):
+                host_time_datapoint[0]['tags']['nomad_job_name'] = os.environ['NOMAD_JOB_NAME']
+            if os.environ.get('NOMAD_ALLOC_INDEX'):
+                host_time_datapoint[0]['tags']['nomad_alloc_index'] = os.environ['NOMAD_ALLOC_INDEX']
 
-            values.append((n for n in exec_time_datapoint))
+
+            values.append((n for n in host_time_datapoint))
             values = itertools.chain(*values)
 
             ### Send results to the right output

--- a/lib/metric_collector/collector.py
+++ b/lib/metric_collector/collector.py
@@ -1,0 +1,113 @@
+import logging
+import requests
+import time
+from metric_collector import netconf_collector
+from metric_collector import f5_rest_collector
+
+logger = logging.getLogger('collector')
+global_measurement_prefix = 'metric_collector'
+
+class Collector:
+
+    def __init__(self, hosts_manager, parser_manager):
+        self.hosts_manager = hosts_manager
+        self.parser_manager = parser_manager
+
+    def collect(self, worker_name, hosts=None, host_cmds=None, cmd_tags=None, dump_queue=None):
+        if not hosts and not host_cmds:
+            logger.error('Collector: Nothing to collect')
+            if dump_queue:
+                dump_queue.put([])
+            return []
+        if hosts:
+            host_cmds = {}
+            tags = cmd_tags or ['.*']
+            for host in hosts:
+                cmds = self.hosts_manager.get_target_commands(host, tags=tags) 
+                target_cmds = []
+                for c in cmds:
+                    target_cmds += c['commands']
+                host_cmds[host] = target_cmds
+               
+        values = []
+        for host, target_commands in host_cmds.items():
+            credential = self.hosts_manager.get_credentials(host)
+
+            host_reacheable = False
+
+            logger.info('Collector starting for: %s', host)
+            host_address = self.hosts_manager.get_address(host)
+            device_type = self.hosts_manager.get_device_type(host)
+
+            if device_type == 'juniper':
+                dev = netconf_collector.NetconfCollector(
+                        host=host, address=host_address, credential=credential, parsers=self.parser_manager)
+            elif device_type == 'f5':
+                dev = f5_rest_collector.F5Collector(
+                    host=host, address=host_address, credential=credential, parsers=self.parser_manager)
+            dev.connect()
+
+            if dev.is_connected():
+                dev.collect_facts()
+                host_reacheable = True
+
+            else:
+                logger.error('Unable to connect to %s, skipping', host)
+                host_reacheable = False
+
+            time_execution = 0
+            cmd_successful = 0
+            cmd_error = 0
+
+            if host_reacheable:
+                time_start = time.time()
+
+                ### Execute commands on the device
+                for command in target_commands:
+                    try:
+                        logger.info('[%s] Collecting > %s' % (host,command))
+                        values += dev.collect(command)
+                        cmd_successful += 1
+
+                    except Exception as err:
+                        cmd_error += 1
+                        logger.error('An issue happened while collecting %s on %s > %s ' % (host,command, err))
+                        logger.error(traceback.format_exc())
+
+                ### Save collector statistics
+                time_end = time.time()
+                time_execution = time_end - time_start
+
+            exec_time_datapoint = [{
+                'measurement': global_measurement_prefix + '_collector_stats',
+                'tags': {
+                    'device': dev.hostname,
+                    'worker_name': worker_name
+                },
+                'fields': {
+                    'execution_time_sec': "%.4f" % time_execution,
+                    'nbr_commands':  cmd_successful + cmd_error,
+                    'nbr_successful_commands':  cmd_successful,
+                    'nbr_error_commands':  cmd_error,
+                    'reacheable': int(host_reacheable),
+                    'unreacheable': int(not host_reacheable)
+                }
+            }]
+
+            values += exec_time_datapoint
+
+            ### if context information are provided add these in the tag list
+            ### the context is a list of dict, go over all element and
+            ### check if a similar tag already exist
+            host_context = self.hosts_manager.get_context(host)
+            for value in values:
+                for item in host_context:
+                    for k, v in item.items():
+                        if k in value['tags']:
+                            continue
+                        value['tags'][k] = v
+
+        if dump_queue:
+            dump_queue.put(values)
+
+        return values

--- a/lib/metric_collector/collector.py
+++ b/lib/metric_collector/collector.py
@@ -1,24 +1,26 @@
 import logging
+import itertools
 import requests
 import time
 from metric_collector import netconf_collector
 from metric_collector import f5_rest_collector
+from metric_collector import utils
 
 logger = logging.getLogger('collector')
 global_measurement_prefix = 'metric_collector'
 
 class Collector:
 
-    def __init__(self, hosts_manager, parser_manager):
+    def __init__(self, hosts_manager, parser_manager, output_type, output_addr):
         self.hosts_manager = hosts_manager
         self.parser_manager = parser_manager
+        self.output_type = output_type
+        self.output_addr = output_addr
 
-    def collect(self, worker_name, hosts=None, host_cmds=None, cmd_tags=None, dump_queue=None):
+    def collect(self, worker_name, hosts=None, host_cmds=None, cmd_tags=None):
         if not hosts and not host_cmds:
             logger.error('Collector: Nothing to collect')
-            if dump_queue:
-                dump_queue.put([])
-            return []
+            return
         if hosts:
             host_cmds = {}
             tags = cmd_tags or ['.*']
@@ -29,45 +31,50 @@ class Collector:
                     target_cmds += c['commands']
                 host_cmds[host] = target_cmds
                
-        values = []
         for host, target_commands in host_cmds.items():
+            values = []
             credential = self.hosts_manager.get_credentials(host)
 
-            host_reacheable = False
+            host_reachable = False
 
             logger.info('Collector starting for: %s', host)
             host_address = self.hosts_manager.get_address(host)
+            host_context = self.hosts_manager.get_context(host)
             device_type = self.hosts_manager.get_device_type(host)
 
             if device_type == 'juniper':
                 dev = netconf_collector.NetconfCollector(
-                        host=host, address=host_address, credential=credential, parsers=self.parser_manager)
+                        host=host, address=host_address, credential=credential,
+                        parsers=self.parser_manager, context=host_context)
             elif device_type == 'f5':
                 dev = f5_rest_collector.F5Collector(
-                    host=host, address=host_address, credential=credential, parsers=self.parser_manager)
+                    host=host, address=host_address, credential=credential,
+                    parsers=self.parser_manager, context=host_context)
             dev.connect()
 
             if dev.is_connected():
                 dev.collect_facts()
-                host_reacheable = True
+                host_reachable = True
 
             else:
                 logger.error('Unable to connect to %s, skipping', host)
-                host_reacheable = False
+                host_reachable = False
 
             time_execution = 0
             cmd_successful = 0
             cmd_error = 0
 
-            if host_reacheable:
+            if host_reachable:
                 time_start = time.time()
 
                 ### Execute commands on the device
                 for command in target_commands:
                     try:
                         logger.info('[%s] Collecting > %s' % (host,command))
-                        values += dev.collect(command)
-                        cmd_successful += 1
+                        data = dev.collect(command)  # returns a generator
+                        if data:
+                            values.append(data)
+                            cmd_successful += 1
 
                     except Exception as err:
                         cmd_error += 1
@@ -89,25 +96,21 @@ class Collector:
                     'nbr_commands':  cmd_successful + cmd_error,
                     'nbr_successful_commands':  cmd_successful,
                     'nbr_error_commands':  cmd_error,
-                    'reacheable': int(host_reacheable),
-                    'unreacheable': int(not host_reacheable)
+                    'reacheable': int(host_reachable),
+                    'unreacheable': int(not host_reachable)
                 }
             }]
 
-            values += exec_time_datapoint
+            values.append((n for n in exec_time_datapoint))
+            values = itertools.chain(*values)
 
-            ### if context information are provided add these in the tag list
-            ### the context is a list of dict, go over all element and
-            ### check if a similar tag already exist
-            host_context = self.hosts_manager.get_context(host)
-            for value in values:
-                for item in host_context:
-                    for k, v in item.items():
-                        if k in value['tags']:
-                            continue
-                        value['tags'][k] = v
+            ### Send results to the right output
+            if self.output_type == 'stdout':
+                utils.print_format_influxdb(values)
+            elif self.output_type == 'http':
+                utils.post_format_influxdb(values, self.output_addr)
+            else:
+                logger.warn('Collector: Output format unknown: {}'.format(self.output_type))
 
-        if dump_queue:
-            dump_queue.put(values)
-
-        return values
+            if host_reachable:
+                dev.close()

--- a/lib/metric_collector/collector.py
+++ b/lib/metric_collector/collector.py
@@ -99,7 +99,8 @@ class Collector:
                     'nbr_error_commands':  cmd_error,
                     'reacheable': int(host_reachable),
                     'unreacheable': int(not host_reachable)
-                }
+                },
+                'timestamp': time.time_ns(),
             }]
             if os.environ.get('NOMAD_JOB_NAME'):
                 host_time_datapoint[0]['tags']['nomad_job_name'] = os.environ['NOMAD_JOB_NAME']

--- a/lib/metric_collector/collector.py
+++ b/lib/metric_collector/collector.py
@@ -2,6 +2,7 @@ import logging
 import itertools
 import requests
 import time
+import os
 from metric_collector import netconf_collector
 from metric_collector import f5_rest_collector
 from metric_collector import utils

--- a/lib/metric_collector/f5_rest_collector.py
+++ b/lib/metric_collector/f5_rest_collector.py
@@ -85,12 +85,14 @@ class F5Collector(object):
 
         if datapoints is not None:
             measurement = self.parsers.get_measurement_name(input=command)
+            timestamp = time.time_ns()
             for datapoint in datapoints:
                 if datapoint['measurement'] is None:
                     datapoint['measurement'] = measurement
                 datapoint['tags'].update(self.facts)
                 if self.context:
                     datapoint['tags'].update(self.context)
+                datapoint['timestamp'] = timestamp
                 yield datapoint
 
         else:

--- a/lib/metric_collector/f5_rest_collector.py
+++ b/lib/metric_collector/f5_rest_collector.py
@@ -9,7 +9,8 @@ logger = logging.getLogger('f5_rest_collector')
 
 class F5Collector(object):
 
-    def __init__(self, host, address, credential, port=443, timeout=30, retry=3, parsers=None):
+    def __init__(self, host, address, credential, port=443, timeout=30, retry=3, parsers=None,
+                 context=None):
         self.hostname = host
         self.host = address
         self.credential = credential
@@ -18,6 +19,10 @@ class F5Collector(object):
         self.__retry = retry
         self.__is_connected = False
         self.parsers = parsers
+        if context:
+            self.context = {k: v for i in context for k, v in i.items()}
+        else:
+            self.context = None
         self.facts = {}
 
     def connect(self):
@@ -80,17 +85,21 @@ class F5Collector(object):
 
         if datapoints is not None:
             measurement = self.parsers.get_measurement_name(input=command)
-            to_return = []
             for datapoint in datapoints:
                 if datapoint['measurement'] is None:
                     datapoint['measurement'] = measurement
                 datapoint['tags'].update(self.facts)
-                to_return.append(datapoint)
+                if self.context:
+                    datapoint['tags'].update(self.context)
+                yield datapoint
 
-            return to_return
         else:
             logger.warn('No parser found for command > %s', command)
             return None
 
     def is_connected(self):
         return self.__is_connected
+
+    def close(self):
+        # rest connection is not stateful so nothing to close
+        return

--- a/lib/metric_collector/host_manager.py
+++ b/lib/metric_collector/host_manager.py
@@ -7,18 +7,15 @@ class HostManager(object):
     Manage the list of hosts
     Help identify what credential & commands needs to be used for each device
     """
-    def __init__(self, inventory, credentials, commands, log='info'):
+    def __init__(self, credentials, commands, log='info'):
 
-        self.hosts = {}
         self.commands = {}
         self.credentials = {}
 
         ### -------------------------------------------------------------
         ### Check data format
         ### -------------------------------------------------------------
-        if not isinstance(inventory, dict):
-            raise Exception("inventory must be a dictionnary of host")
-        elif not isinstance(credentials, dict):
+        if not isinstance(credentials, dict):
             raise Exception("credential must be a dictionnary")
         elif not isinstance(commands, dict):
             raise Exception("commands must be a dictionnary")
@@ -36,37 +33,6 @@ class HostManager(object):
             self.log.setLevel(logging.ERROR)
         else:
             self.log.setLevel(logging.INFO)
-
-        ### -------------------------------------------------------------    
-        ### Check list of hosts provided
-        ### -------------------------------------------------------------
-        for host in inventory.keys():
-            if isinstance(inventory[host], dict):
-
-                ## TODO check if the dictionnary contain at least tags and address
-                if 'tags' not in inventory[host]:
-                    self.log.warn('host: tags are missing for %s, not supported, skipping' % host)
-                    continue
-                elif 'address' not in inventory[host]:
-                    self.log.warn('host: address is missing for %s, not supported, skipping' % host)
-                    continue
-
-                self.hosts[host] = inventory[host]
-
-                if 'context' not in self.hosts[host]: 
-                    self.hosts[host]['context'] = []
-                
-            elif isinstance(inventory[host], str):
-
-                tags = inventory[host].split()
-                self.hosts[host] = {
-                    'tags': tags,
-                    'address': host,
-                    'context': []
-                }
-
-            else:
-                self.log.warn('host: format for %s not spported, skipping' % host)
 
         ### -------------------------------------------------------------    
         ### Check commands provided
@@ -184,8 +150,43 @@ class HostManager(object):
                 credential['port'] = credentials[credential_grp]['port']
 
             self.credentials[credential_grp] = credential
-                   
-                    
+
+
+    def update_hosts(self, inventory):
+        self.hosts = {}
+        if not isinstance(inventory, dict):
+            raise Exception("inventory must be a dictionnary of host")
+        ### -------------------------------------------------------------
+        ### Check list of hosts provided
+        ### -------------------------------------------------------------
+        for host in inventory.keys():
+            if isinstance(inventory[host], dict):
+
+                ## TODO check if the dictionnary contain at least tags and address
+                if 'tags' not in inventory[host]:
+                    self.log.warn('host: tags are missing for %s, not supported, skipping' % host)
+                    continue
+                elif 'address' not in inventory[host]:
+                    self.log.warn('host: address is missing for %s, not supported, skipping' % host)
+                    continue
+
+                self.hosts[host] = inventory[host]
+
+                if 'context' not in self.hosts[host]:
+                    self.hosts[host]['context'] = []
+
+            elif isinstance(inventory[host], str):
+
+                tags = inventory[host].split()
+                self.hosts[host] = {
+                    'tags': tags,
+                    'address': host,
+                    'context': []
+                }
+
+            else:
+                self.log.warn('host: format for %s not spported, skipping' % host)
+
 
     def get_target_hosts(self, tags=[]):
         """

--- a/lib/metric_collector/netconf_collector.py
+++ b/lib/metric_collector/netconf_collector.py
@@ -154,12 +154,14 @@ class NetconfCollector():
 
       measurement = self.parsers.get_measurement_name(input=command)
 
+      timestamp = time.time_ns()
       for datapoint in datapoints:
         if datapoint['measurement'] == None:
           datapoint['measurement'] = measurement
         datapoint['tags'].update(self.facts)
         if self.context:
           datapoint['tags'].update(self.context)
+        datapoint['timestamp'] = timestamp
         yield datapoint
 
     else:

--- a/lib/metric_collector/netconf_collector.py
+++ b/lib/metric_collector/netconf_collector.py
@@ -132,21 +132,23 @@ class NetconfCollector():
 
     try:
       logger.debug('[%s]: execute : %s', self.hostname, command)
-      # Remember... all rpc must have format=xml at execution time,
+      # the data returned is already in etree format
       command_result = self.pyez.rpc.cli(command, format="xml")
     except RpcError as err:
       rpc_error = err.__repr__()
       logger.error("Error found on <%s> executing command: %s, error: %s:", self.hostname, command ,rpc_error)
       return False
 
-    return etree.tostring(command_result)
+    return command_result
 
   def collect( self, command=None ):
 
     # find the command to execute from the parser directly
     parser = self.parsers.get_parser_for(command)
-    raw_data = self.execute_command(parser['data']['parser']['command'])
-    datapoints = self.parsers.parse(input=command, data=raw_data)
+    data = self.execute_command(parser['data']['parser']['command'])
+    if parser['data']['parser']['type'] == 'textfsm':
+        data = etree.tostring(data)
+    datapoints = self.parsers.parse(input=command, data=data)
     
     if datapoints is not None:
 

--- a/lib/metric_collector/parser_manager.py
+++ b/lib/metric_collector/parser_manager.py
@@ -245,7 +245,9 @@ class ParserManager:
   def __parse_xml__(self, parser=None, data=None):
 
     datas_to_return = []
-
+    if not data or not parser:
+        logger.debug('No data or parser found')
+        return datas_to_return
     logger.debug("will parse %s with xml" % parser['command'])
     # logger.debug("data %s" % data)
     ## Empty structure that needs to be filled and return for each input

--- a/lib/metric_collector/parser_manager.py
+++ b/lib/metric_collector/parser_manager.py
@@ -249,10 +249,6 @@ class ParserManager:
         return
     logger.debug("will parse %s with xml" % parser['command'])
 
-    clean_data = re.sub(r"\sxmlns\=\".*\"", '', data.decode(), re.M)
-    clean_data = re.sub(r"\sjunos\:", ' ', clean_data, re.M)
-    xml_data = etree.fromstring(clean_data, parser=etree.XMLParser(collect_ids=False))
-
     for match in parser["data"]["parser"]["matches"]:
         ## Empty structure that needs to be filled and return for each input
         data_structure = {
@@ -264,7 +260,7 @@ class ParserManager:
         if match["type"] == "single-value":
           
           logger.debug('Looking for a match: %s', match["xpath"])
-          value_tmp = xml_data.xpath(match["xpath"])
+          value_tmp = data.xpath(match["xpath"])
           if value_tmp:
           
             if 'variable-name' in match:
@@ -294,7 +290,7 @@ class ParserManager:
 
         elif match["type"] == "multi-value":
 
-          nodes = xml_data.xpath(match["xpath"])
+          nodes = data.xpath(match["xpath"])
           for node in nodes:
 
             ## Assign measurement name if defined 

--- a/lib/metric_collector/parser_manager.py
+++ b/lib/metric_collector/parser_manager.py
@@ -251,13 +251,13 @@ class ParserManager:
 
     for match in parser["data"]["parser"]["matches"]:
         ## Empty structure that needs to be filled and return for each input
-        data_structure = {
+
+        if match["type"] == "single-value":
+          data_structure = {
             'measurement': None,
             'tags': {},
             'fields': {}
-        }
-
-        if match["type"] == "single-value":
+          }
           
           logger.debug('Looking for a match: %s', match["xpath"])
           value_tmp = data.xpath(match["xpath"])
@@ -292,6 +292,11 @@ class ParserManager:
 
           nodes = data.xpath(match["xpath"])
           for node in nodes:
+            data_structure = {
+              'measurement': None,
+              'tags': {},
+              'fields': {}
+            }
 
             ## Assign measurement name if defined 
             if 'measurement' in match:

--- a/lib/metric_collector/parser_manager.py
+++ b/lib/metric_collector/parser_manager.py
@@ -244,31 +244,22 @@ class ParserManager:
 
   def __parse_xml__(self, parser=None, data=None):
 
-    datas_to_return = []
     if not data or not parser:
         logger.debug('No data or parser found')
-        return datas_to_return
+        return
     logger.debug("will parse %s with xml" % parser['command'])
-    # logger.debug("data %s" % data)
-    ## Empty structure that needs to be filled and return for each input
-    data_structure = {
-        'measurement': None,
-        'tags': {},
-        'fields': {}
-    }
-
-    single_match = copy.deepcopy(data_structure)
 
     clean_data = re.sub(r"\sxmlns\=\".*\"", '', data.decode(), re.M)
     clean_data = re.sub(r"\sjunos\:", ' ', clean_data, re.M)
-    xml_data = etree.fromstring(clean_data)
-
-    ## NOTE, There is an assumption that all matches will be either
-    # - single-value
-    # - multi-value
-    ## it might not work as it, if we have a mix of both
+    xml_data = etree.fromstring(clean_data, parser=etree.XMLParser(collect_ids=False))
 
     for match in parser["data"]["parser"]["matches"]:
+        ## Empty structure that needs to be filled and return for each input
+        data_structure = {
+            'measurement': None,
+            'tags': {},
+            'fields': {}
+        }
 
         if match["type"] == "single-value":
           
@@ -282,61 +273,38 @@ class ParserManager:
               key_name = self.cleanup_xpath(match['xpath'])
 
             if isinstance(value_tmp[0], str):
-              single_match['fields'][key_name] = value_tmp[0].strip()
+              data_structure['fields'][key_name] = value_tmp[0].strip()
             else:
-              single_match['fields'][key_name] = value_tmp[0].text.strip()
+              data_structure['fields'][key_name] = value_tmp[0].text.strip()
 
           else:
             logger.debug('No match found: %s', match["xpath"])
-            if 'default-if-missing' in match.keys():
+            if 'default-if-missing' in match:
               logger.debug('Inserting default-if-missing value: %s', match["default-if-missing"])
               value_tmp = match["default-if-missing"]
 
-              if 'variable-name' in match.keys():
+              if 'variable-name' in match:
                 key_tmp = match['variable-name']
               else: 
                 key_tmp = self.cleanup_xpath(match['xpath'])
 
-              single_match['fields'][key_tmp] = value_tmp
+              data_structure['fields'][key_tmp] = value_tmp
+
+          yield data_structure
 
         elif match["type"] == "multi-value":
 
           nodes = xml_data.xpath(match["xpath"])
           for node in nodes:
-            #Look for all posible keys or fields to extract and be used for variable-naming
-            #key = node.xpath(match["loop"]["key"])[0].text.replace(" ","_").strip()
-
-            keys = {}
-            tmp_data = copy.deepcopy(data_structure)
-            keys_tmp = copy.deepcopy(match["loop"])
 
             ## Assign measurement name if defined 
             if 'measurement' in match:
-              tmp_data['measurement'] = match['measurement']
-
-            if 'sub-matches' in keys_tmp.keys():
-              del keys_tmp['sub-matches']
-
-            for key_tmp in keys_tmp.keys():
-              key_name = key_tmp
-
-              key_results = node.xpath(keys_tmp[key_tmp])
-
-              if len(key_results) == 0:
-                continue
-              
-              if isinstance(key_results[0], str):
-                tmp_data['tags'][key_name] = self.cleanup_tag(key_results[0].strip())
-              else:
-                tmp_data['tags'][key_name] = self.cleanup_tag(key_results[0].text.strip())
-
-              ## Cleanup string
-              tmp_data['tags'][key_name].replace(" ","_")
+              data_structure['measurement'] = match['measurement']
 
             for sub_match in match["loop"]["sub-matches"]:
 
               if node.xpath(sub_match["xpath"]):
-                if "regex" in sub_match.keys():
+                if "regex" in sub_match:
 
                     if isinstance(node.xpath(sub_match["xpath"])[0], str):
                       value_tmp = node.xpath(sub_match["xpath"])[0].strip()
@@ -355,7 +323,7 @@ class ParserManager:
                           # Begin function  (pero pendiente de ver si variable-type existe y su valor)
                           if "variable-type" in sub_match["variables"][i]:
                             value = self.eval_variable_value(value, type=sub_match["variables"][i]["variable-type"])
-                          tmp_data['fields'][variable_name] = value
+                          data_structure['fields'][variable_name] = value
                       else:
                         logger.error('More matches found on regex %s for %s than variables specified on parser', regex, value_tmp)
                     else:
@@ -367,68 +335,67 @@ class ParserManager:
                     else:
                       value_tmp = node.xpath(sub_match["xpath"])[0].text.strip()
 
-                    if 'variable-name' in sub_match.keys():
+                    if 'variable-name' in sub_match:
                       key_tmp = sub_match['variable-name']
                     else: 
                       key_tmp = self.cleanup_xpath(sub_match['xpath'])
                     
-                    if 'transform' in sub_match.keys():
+                    if 'transform' in sub_match:
                       if sub_match['transform'] == 'str_2_int':
                         value_tmp = self.str_2_int(value_tmp)
 
-                    if 'variable-type' in sub_match.keys():
+                    if 'variable-type' in sub_match:
                       value_tmp = self.eval_variable_value(value_tmp, type=sub_match['variable-type'])
-                      tmp_data['fields'][key_tmp] = value_tmp
+                      data_structure['fields'][key_tmp] = value_tmp
                     
-                    if 'enumerate' in sub_match.keys():
+                    if 'enumerate' in sub_match:
                       enum_match = False
                       for enum_item in sub_match['enumerate']:
                         if value_tmp == enum_item:
                           enum_match = True
-                          tmp_data['fields'][key_tmp] = sub_match['enumerate'][enum_item]
+                          data_structure['fields'][key_tmp] = sub_match['enumerate'][enum_item]
                         
-                      if not enum_match and 'default-if-missing' in sub_match.keys():
-                        tmp_data['fields'][key_tmp] = sub_match['default-if-missing']
+                      if not enum_match and 'default-if-missing' in sub_match:
+                        data_structure['fields'][key_tmp] = sub_match['default-if-missing']
                       elif not enum_match:
-                        tmp_data['fields'][key_tmp] = 0
+                        data_structure['fields'][key_tmp] = 0
 
-                    elif value_tmp and key_tmp not in tmp_data['fields']:
-                      tmp_data['fields'][key_tmp] = value_tmp
+                    elif value_tmp and key_tmp not in data_structure['fields']:
+                      data_structure['fields'][key_tmp] = value_tmp
 
               else:
                   logger.debug('No match found: %s', match["xpath"])
-                  if 'default-if-missing' in sub_match.keys():
+                  if 'default-if-missing' in sub_match:
                     logger.debug('Inserting default-if-missing value: %s', sub_match["default-if-missing"])
                     value_tmp = sub_match["default-if-missing"]
-                    if 'variable-name' in sub_match.keys():
+                    if 'variable-name' in sub_match:
                       key_tmp = sub_match['variable-name']
                     else: 
                       key_tmp = self.cleanup_xpath(sub_match['xpath'])
                     
-                    tmp_data['fields'][key_tmp] = value_tmp
+                    data_structure['fields'][key_tmp] = value_tmp
 
-            datas_to_return.append(tmp_data)
+           
+            # parse the tags
+            for key, value in match["loop"].items():
+              if key == 'sub-matches':
+                continue
+              key_results = node.xpath(value)
+              if len(key_results) == 0:
+                continue
 
-    # if it's not empty, add it to the list
-    if len(single_match['fields'].keys()) > 0:
-      datas_to_return.append(single_match)
+              if isinstance(key_results[0], str):
+                data_structure['tags'][key] = self.cleanup_tag(key_results[0].strip())
+              else:
+                data_structure['tags'][key] = self.cleanup_tag(key_results[0].text.strip())
 
-    return datas_to_return
+              ## Cleanup string
+              data_structure['tags'][key].replace(" ","_")
+
+            yield data_structure
 
 
   def __parse_textfsm__(self, parser=None, data=None):
-
-    datas_to_return = []
-
-    ## Empty structure that needs to be filled and return for each input
-    data_structure = {
-        'measurement': None,
-        'tags': {},
-        'fields': {}
-    }
-
-    if 'measurement' in parser:
-      data_structure['measurement'] = parser['measurement']
 
     ## TODO Check if template exist
     tpl_file = StringIO(parser['data']['parser']['template'])
@@ -440,7 +407,16 @@ class ParserManager:
     headers = list(res_table.header)
     ## Extract 
     for row in res_data:
-      tmp_data = copy.deepcopy(data_structure)
+
+      ## Empty structure that needs to be filled and return for each input
+      data_structure = {
+          'measurement': None,
+          'tags': {},
+          'fields': {}
+      }
+
+      if 'measurement' in parser:
+        data_structure['measurement'] = parser['measurement']
         
       for field in parser['data']['parser']['fields']:
         if field not in headers: 
@@ -455,7 +431,7 @@ class ParserManager:
         else:
           value = row[idx]
 
-        tmp_data['fields'][field_name] = str(value)
+        data_structure['fields'][field_name] = str(value)
         
       for tag in parser['data']['parser']['tags']:
         if tag not in headers: 
@@ -463,13 +439,10 @@ class ParserManager:
         
         idx = headers.index(tag)
         tag_name = parser['data']['parser']['tags'][tag]
-        tmp_data['tags'][tag_name] = self.cleanup_tag(row[idx])
-         
-      datas_to_return.append(tmp_data)
+        data_structure['tags'][tag_name] = self.cleanup_tag(row[idx])
+      
+      yield data_structure
   
-    # pprint.pprint(datas_to_return)
-    return datas_to_return
-
 
   def __parse_regex__(self, parser=None, data=None):
 

--- a/lib/metric_collector/scheduler.py
+++ b/lib/metric_collector/scheduler.py
@@ -1,0 +1,173 @@
+import logging
+import queue
+import threading
+import time
+from itertools import cycle
+from metric_collector import collector, utils
+
+logger = logging.getLogger('scheduler')
+
+class Scheduler:
+
+    def __init__(self, shard_id, host_mgr, parser_mgr, output_type, output_addr,
+                 max_worker_threads=1, use_threads=True, num_threads_per_worker=10):
+        self.shard_id = shard_id
+        self.workers = {}
+        self.working = set()
+        self.collector = collector.Collector(host_mgr, parser_mgr)
+        self.host_mgr = host_mgr
+        self.max_worker_threads = max_worker_threads
+        self.output_type = output_type
+        self.output_addr = output_addr
+        self.use_threads = use_threads
+        self.num_threads_per_worker = num_threads_per_worker
+        # default worker that is started if there are no hosts to schedule
+        self.default_worker = Worker(
+            120, self.collector, self.output_type, self.output_addr,
+            self.use_threads, self.num_threads_per_worker)
+        self.default_worker.set_name('Default-120sec', shard_id)
+
+    def _get_workers(self, interval):
+        ''' Spin off worker threads for each type of command based on interval '''
+        interval_workers = self.workers.get(interval)
+        if not interval_workers:
+            workers = [
+                Worker(interval, self.collector, self.output_type, self.output_addr, 
+                       self.use_threads, self.num_threads_per_worker)
+                for _ in range(self.max_worker_threads)
+            ]
+            for i, w in enumerate(workers, 1):
+                w.set_name('Worker-{}sec-{}'.format(interval, i), self.shard_id)
+            interval_workers = cycle(workers)
+            self.workers[interval] = interval_workers
+        return interval_workers
+
+    def add_hosts(self, hosts, cmd_tags=None):
+        '''  Create worker threads per interval and round-robin the hosts amongst them '''
+        if not hosts:
+            logger.error('Scheduler: No hosts')
+            return
+        tags = cmd_tags or ['.*']
+        for host in hosts:
+            target_commands = self.host_mgr.get_target_commands(host, tags=tags) 
+            if not target_commands:
+                logger.error('Scheduler: No commands found for host: {}'.format(host))
+            for cmd in target_commands:
+                workers = self._get_workers(cmd['interval_secs'])
+                next_worker = next(workers)
+                next_worker.add_host(host, cmd['commands'])
+                self.working.add(next_worker)
+
+    def start(self):
+        ''' Start all worker threads and block until stopped '''
+        if len(self.working) == 0:
+            self.working.add(self.default_worker)
+        for worker in self.working:
+            worker.start()
+        for worker in self.working:
+            worker.join()
+
+    def stop(self):
+        ''' Stop all running worker threads '''
+        for worker in self.working:
+            worker.stop()
+
+
+class Worker(threading.Thread):
+    ''' Worker is responsible for running a set of commands per host at regular intervals
+        and dumping to output
+    '''
+
+    def __init__(self, interval, collector, output_type, output_addr, use_threads, num_collector_threads):
+        super().__init__()
+        self.interval = interval
+        self.collector = collector
+        self.num_collector_threads = num_collector_threads
+        self.use_threads = use_threads
+        self.output_type = output_type
+        self.output_addr = output_addr
+        self.hostcmds = {}
+        self._queue = queue.Queue()
+        self._run = True
+
+    def set_name(self, name, shard_id):
+        self.name = name
+        self.shard_id = shard_id
+
+    def stop(self):
+        self._run = False
+
+    def add_host(self, host, cmds):
+        commands = self.hostcmds.setdefault(host, [])
+        commands += cmds
+
+    def run(self):
+        ''' Main run loop '''
+        while True:
+            if not self._run:
+                return
+            logger.info('{}: Starting collection for {} hosts'.format(
+                self.name, len(self.hostcmds)))
+            hosts = list(self.hostcmds.keys())
+            time_start = time.time()
+            if self.use_threads:
+                values = []
+                target_hosts_lists = [
+                    hosts[x: x + int(len(hosts) / self.num_collector_threads + 1)]
+                        for x in range(
+                            0, len(hosts), int(len(hosts) / self.num_collector_threads + 1)
+                        )
+                ]       
+                jobs = []
+                for i, target_hosts_list in enumerate(target_hosts_lists, 1):
+                    logger.info('{}: Collector Thread-{} scheduled with following hosts: {}'.format(
+                        self.name, i, target_hosts_list))
+                    hostcmds = {}
+                    for host in target_hosts_list:
+                        hostcmds[host] = self.hostcmds[host]
+                    job = threading.Thread(target=self.collector.collect,
+                                           args=(self.name,),
+                                           kwargs={"host_cmds": hostcmds,
+                                                   "dump_queue": self._queue})
+                    job.start()
+                    jobs.append(job)
+
+                # Ensure all of the threads have finished
+                for j in jobs:
+                    j.join()
+                    values += self._queue.get()
+
+            else:
+                # Execute everythings in the main thread
+                values = self.collector.collect(self.name, host_cmds=self.hostcmds)
+
+            time_end = time.time()
+            time_execution = time_end - time_start
+            global_datapoint = [
+                {
+                    'measurement': collector.global_measurement_prefix + '_worker_stats',
+                    'tags': {'worker_name': self.name},
+                    'fields': {
+                        'execution_time_sec': "%.4f" % time_execution,
+                        'nbr_devices': len(self.hostcmds),
+                        'nbr_threads': self.num_collector_threads
+                    }
+                }
+            ]
+            if self.shard_id is not None:
+                global_datapoint[0]['tags']['shard_id'] = self.shard_id
+            if self.use_threads:
+                global_datapoint[0]['fields']['nbr_threads'] = self.num_collector_threads
+
+            values += global_datapoint
+
+            ### Send results to the right output
+            if self.output_type == 'stdout':
+                utils.print_format_influxdb(values)
+            elif self.output_type == 'http':
+                utils.post_format_influxdb(values, self.output_addr)
+            else:
+                logger.warn('{}: Output format unknown: {}'.format(self.name, self.output_type))
+
+            # sleep until next interval
+            time.sleep(self.interval)

--- a/lib/metric_collector/scheduler.py
+++ b/lib/metric_collector/scheduler.py
@@ -164,7 +164,7 @@ class Worker(threading.Thread):
             if os.environ.get('NOMAD_JOB_NAME'):
                 worker_datapoint[0]['tags']['nomad_job_name'] = os.environ['NOMAD_JOB_NAME']
             if os.environ.get('NOMAD_ALLOC_INDEX'):
-                worker_datapoint[0]['tags']['nomad_alloc_index'] = os.environ['NOMAD_ALLOC_INDEX']1
+                worker_datapoint[0]['tags']['nomad_alloc_index'] = os.environ['NOMAD_ALLOC_INDEX']
 
 
             ### Send results to the right output

--- a/lib/metric_collector/utils.py
+++ b/lib/metric_collector/utils.py
@@ -55,9 +55,9 @@ def format_datapoints_inlineprotocol(datapoints):
             fields = fields + '{0}={1}'.format(tag,value)
 
         if datapoint['tags']:
-          formatted_data = "{0},{1} {2}".format(datapoint['measurement'], tags, fields)
+          formatted_data = "{0},{1} {2} {3}".format(datapoint['measurement'], tags, fields, datapoint['timestamp'])
         else:
-          formatted_data = "{0} {1}".format(datapoint['measurement'], fields)
+          formatted_data = "{0} {1} {2}".format(datapoint['measurement'], fields, datapoint['timestamp'])
         yield formatted_data
 
 

--- a/lib/metric_collector/utils.py
+++ b/lib/metric_collector/utils.py
@@ -1,0 +1,59 @@
+import logging
+import requests
+
+logger = logging.getLogger('collector')
+
+def print_format_influxdb(datapoints):
+    """
+    Print all datapoints to STDOUT in influxdb format for Telegraf to pick them up
+    """
+    for data in format_datapoints_inlineprotocol(datapoints):
+        print(data)
+
+def post_format_influxdb(datapoints, addr="http://localhost:8186/write"):
+    s = requests.session()
+    for datapoint in format_datapoints_inlineprotocol(datapoints):
+        s.post(addr, data=datapoint)
+
+    logger.info('Sending Datapoint to: %s' % addr)
+
+def format_datapoints_inlineprotocol(datapoints):
+    """
+    Format all datapoints with the inlineprotocol (influxdb)
+    Return a list of string formatted datapoint
+    """
+
+    formatted_data = []
+
+    ## Format Tags
+    if datapoints is not None:
+      for datapoint in datapoints:
+          tags = ''
+          first_tag = 1
+          for tag, value in datapoint['tags'].items():
+
+              if first_tag == 1:
+                  first_tag = 0
+              else:
+                  tags = tags + ','
+
+              tags = tags + '{0}={1}'.format(tag,value)
+
+          ## Format Measurement
+          fields = ''
+          first_field = 1
+          for tag, value in datapoint['fields'].items():
+
+              if first_field == 1:
+                  first_field = 0
+              else:
+                  fields = fields + ','
+
+              fields = fields + '{0}={1}'.format(tag,value)
+
+          if datapoint['tags']:
+            formatted_data.append("{0},{1} {2}".format(datapoint['measurement'], tags, fields))
+          else:
+            formatted_data.append("{0} {1}".format(datapoint['measurement'], fields))
+
+    return formatted_data

--- a/parsers/show-interfaces-extensive.parser.yaml
+++ b/parsers/show-interfaces-extensive.parser.yaml
@@ -22,6 +22,8 @@ parser:
             -   { xpath: ./traffic-statistics/output-bytes,         variable-name: output-bytes }
             -   { xpath: ./traffic-statistics/input-packets,        variable-name: input-packets }
             -   { xpath: ./traffic-statistics/output-packets,       variable-name: output-packets }
+            -   { xpath: ./traffic-statistics/input-bps,        variable-name: input-bps }
+            -   { xpath: ./traffic-statistics/output-bps,        variable-name: output-bps } 
             -   { xpath: ./traffic-statistics/ipv6-transit-statistics/input-bytes,          variable-name: ipv6-input-bytes }
             -   { xpath: ./traffic-statistics/ipv6-transit-statistics/output-bytes,         variable-name: ipv6-output-bytes }
             -   { xpath: ./traffic-statistics/ipv6-transit-statistics/input-packets,        variable-name: ipv6-input-packets }

--- a/tests/unit/test_host_manager.py
+++ b/tests/unit/test_host_manager.py
@@ -70,18 +70,17 @@ class Test_Validate_Main_Block(unittest.TestCase):
  
   def test_import_host_manager(self):
 
-    hm = HostManager( inventory=inventory_2,
-                      credentials=cred_pwd_01,
+    hm = HostManager( credentials=cred_pwd_01,
                       commands=commands_1 )
-
+    hm.update_hosts(inventory_2)
     self.assertTrue(1)
 
 
   def test_get_target_hosts_new_format(self):
 
-    hm = HostManager( inventory=inventory_2,
-                      credentials=cred_pwd_01,
+    hm = HostManager( credentials=cred_pwd_01,
                       commands=commands_1 )
+    hm.update_hosts(inventory_2)
 
     self.assertEqual(hm.get_target_hosts(), [])
     self.assertEqual(hm.get_target_hosts([".*"]), ['router1', 'switch1' ])
@@ -89,9 +88,9 @@ class Test_Validate_Main_Block(unittest.TestCase):
   
   def test_get_target_hosts_old_format(self):
 
-    hm = HostManager( inventory=inventory_1,
-                      credentials=cred_pwd_01,
+    hm = HostManager( credentials=cred_pwd_01,
                       commands=commands_1 )
+    hm.update_hosts(inventory_1)
 
     self.assertEqual(hm.get_target_hosts(), [])
     self.assertEqual(hm.get_target_hosts([".*"]), ['10.10.0.1', '20.20.0.20' ])
@@ -100,9 +99,9 @@ class Test_Validate_Main_Block(unittest.TestCase):
 
   def test_get_target_commands_new_format(self):
 
-    hm = HostManager( inventory=inventory_2,
-                      credentials=cred_pwd_01,
+    hm = HostManager( credentials=cred_pwd_01,
                       commands=commands_1 )
+    hm.update_hosts(inventory_2)
 
     cmds = hm.get_target_commands('router1')
     all_cmds = [c for cmd in cmds for c in cmd['commands']]
@@ -116,9 +115,9 @@ class Test_Validate_Main_Block(unittest.TestCase):
   
   def test_get_target_commands_command_tag(self):
 
-      hm = HostManager( inventory=inventory_2,
-                        credentials=cred_pwd_01,
+      hm = HostManager( credentials=cred_pwd_01,
                         commands=commands_1 )
+      hm.update_hosts(inventory_2)
       cmds = hm.get_target_commands('switch1',tags=['1m'])
       self.assertEqual(cmds[0]['commands'], 
                       ['show test2'])
@@ -129,9 +128,9 @@ class Test_Validate_Main_Block(unittest.TestCase):
 
   def test_get_credentials_default_port(self):
 
-      hm = HostManager( inventory=inventory_2,
-                        credentials=cred_pwd_01,
+      hm = HostManager( credentials=cred_pwd_01,
                         commands=commands_1 )
+      hm.update_hosts(inventory_2)
 
       self.assertEqual(hm.get_credentials('router1'), { 'key_file': None, 
                                                         'method': 'password', 
@@ -142,10 +141,9 @@ class Test_Validate_Main_Block(unittest.TestCase):
 
   def test_get_credentials_not_default_port(self):
 
-      hm = HostManager( inventory=inventory_2,
-                        credentials=cred_pwd_02,
+      hm = HostManager( credentials=cred_pwd_02,
                         commands=commands_1 )
-
+      hm.update_hosts(inventory_2)
       self.assertEqual(hm.get_credentials('router1'), { 'key_file': None, 
                                                         'method': 'password', 
                                                         'password': 'pwd1',
@@ -155,10 +153,9 @@ class Test_Validate_Main_Block(unittest.TestCase):
         
   def test_get_context(self):
 
-      hm = HostManager( inventory=inventory_2,
-                        credentials=cred_pwd_02,
+      hm = HostManager( credentials=cred_pwd_02,
                         commands=commands_1 )
-
+      hm.update_hosts(inventory_2)
       expected_list = [
         { 'site': 'site1' },
         { 'role': 'router' }

--- a/tests/unit/test_host_manager.py
+++ b/tests/unit/test_host_manager.py
@@ -104,22 +104,27 @@ class Test_Validate_Main_Block(unittest.TestCase):
                       credentials=cred_pwd_01,
                       commands=commands_1 )
 
-    self.assertEqual(hm.get_target_commands('router1'), 
-                    ['show cpu', 'show test2', 'show version'])
+    cmds = hm.get_target_commands('router1')
+    all_cmds = [c for cmd in cmds for c in cmd['commands']]
+    self.assertEqual(sorted(all_cmds), 
+                    sorted(['show cpu', 'show test2', 'show version']))
 
-    self.assertEqual(hm.get_target_commands('switch1'), 
-                    ['show test2', 'show test3'])
+    cmds = hm.get_target_commands('switch1')
+    all_cmds = [c for cmd in cmds for c in cmd['commands']]
+    self.assertEqual(sorted(all_cmds), 
+                    sorted(['show test2', 'show test3']))
   
   def test_get_target_commands_command_tag(self):
 
       hm = HostManager( inventory=inventory_2,
                         credentials=cred_pwd_01,
                         commands=commands_1 )
-
-      self.assertEqual(hm.get_target_commands('switch1',tags=['1m']), 
+      cmds = hm.get_target_commands('switch1',tags=['1m'])
+      self.assertEqual(cmds[0]['commands'], 
                       ['show test2'])
 
-      self.assertEqual(hm.get_target_commands('switch1',tags=['5m']), 
+      cmds = hm.get_target_commands('switch1',tags=['5m'])
+      self.assertEqual(cmds[0]['commands'], 
                       ['show test3'])
 
   def test_get_credentials_default_port(self):

--- a/tests/unit/test_parser_manager.py
+++ b/tests/unit/test_parser_manager.py
@@ -106,7 +106,7 @@ class Test_Validate_Main_Block(unittest.TestCase):
         'tags': {   'key': 'inet6.0'}
     }
 
-    data = pm.parse( input="show-route-summary.parser.yaml", data=xml_data.encode() )
+    data = list(pm.parse( input="show-route-summary.parser.yaml", data=xml_data.encode()))
 
     self.assertDictEqual( expected_dict_0, data[0] )
     self.assertDictEqual( expected_dict_1, data[1] )
@@ -148,7 +148,7 @@ class Test_Validate_Main_Block(unittest.TestCase):
     xml_data = open( test_dir + "/rpc-reply/show_system_processes_extensive/command_short.xml").read()
 
     ## Return a list dict
-    data = pm.parse( input="show-system-processes-extensive.parser.yaml", data=xml_data.encode() )
+    data = list(pm.parse( input="show-system-processes-extensive.parser.yaml", data=xml_data.encode()))
 
     # pp.pprint(data)
     expected_dict_1 = {

--- a/tests/unit/test_parser_manager.py
+++ b/tests/unit/test_parser_manager.py
@@ -6,6 +6,7 @@ import pprint
 import json
 from os import path
 from metric_collector import parser_manager
+from lxml import etree
 
 here = path.abspath(path.dirname(__file__))
 
@@ -86,6 +87,7 @@ class Test_Validate_Main_Block(unittest.TestCase):
 
     ## Read XML content
     xml_data = open( test_dir + "/rpc-reply/show_route_summary/command.xml").read()
+    xml_etree = etree.fromstring(xml_data)
 
     expected_dict_0 = {
         'fields': {   'active-route-count': '16',
@@ -106,7 +108,7 @@ class Test_Validate_Main_Block(unittest.TestCase):
         'tags': {   'key': 'inet6.0'}
     }
 
-    data = list(pm.parse( input="show-route-summary.parser.yaml", data=xml_data.encode()))
+    data = list(pm.parse( input="show-route-summary.parser.yaml", data=xml_etree))
 
     self.assertDictEqual( expected_dict_0, data[0] )
     self.assertDictEqual( expected_dict_1, data[1] )


### PR DESCRIPTION
- adds a simple scheduler the logic is as follows
  - the sharding at the global level will shard the host list and supplies N hosts to the script
  - Each command definition now has an interval associated with it. 
  - There are M worker threads per interval and the N hosts are round-robin'd amongst them. Worker is responsible for running a set of commands per host 
  - Each worker thread further distributes the host load amongst Y collector threads

- make the code more efficient : remove unnecessary copies, avoid large list creation, group datapoints in batches of 1000 to send to ingest