### PR TITLE
Fix to ignore datapoints that have no fields

### DIFF
--- a/lib/metric_collector/f5_rest_collector.py
+++ b/lib/metric_collector/f5_rest_collector.py
@@ -87,6 +87,8 @@ class F5Collector(object):
             measurement = self.parsers.get_measurement_name(input=command)
             timestamp = time.time_ns()
             for datapoint in datapoints:
+                if not datapoint['fields']:
+                    continue
                 if datapoint['measurement'] is None:
                     datapoint['measurement'] = measurement
                 datapoint['tags'].update(self.facts)

--- a/lib/metric_collector/netconf_collector.py
+++ b/lib/metric_collector/netconf_collector.py
@@ -156,6 +156,8 @@ class NetconfCollector():
 
       timestamp = time.time_ns()
       for datapoint in datapoints:
+        if not datapoint['fields']:
+            continue
         if datapoint['measurement'] == None:
           datapoint['measurement'] = measurement
         datapoint['tags'].update(self.facts)


### PR DESCRIPTION
some devices are not returning the expected fields correctly (e.g mgmt switches in ash and some lbs in chi1 ). This diff ignores the datapoints that have no fields due to failed parsing.