### PR TITLE
 Fix issue wit host-manager matching on partial tag

### DIFF
--- a/lib/metric_collector/host_manager.py
+++ b/lib/metric_collector/host_manager.py
@@ -226,7 +226,7 @@ class HostManager(object):
         for group_command, command in self.commands.items():
             for host_tag in host_tags:
                 for command_tag in command['tags']:
-                    if re.search(host_tag, command_tag, re.IGNORECASE):
+                    if re.search( r'^{tag}$'.format(tag=host_tag), command_tag, re.IGNORECASE):
                         groups_matched.append(group_command)
 
         ## Second do a pass on command tag on the list of group_command that passed the previous check
@@ -234,7 +234,7 @@ class HostManager(object):
         for group_command in groups_matched:
             for tag in tags:
                 for command_tag in self.commands[group_command]['tags']:
-                    if re.search(tag, command_tag, re.IGNORECASE):
+                    if re.search( r'^{tag}$'.format(tag=tag), command_tag, re.IGNORECASE):
                         final.add(group_command)
 
         return [self.commands[group] for group in final]

--- a/lib/metric_collector/parser_manager.py
+++ b/lib/metric_collector/parser_manager.py
@@ -244,7 +244,7 @@ class ParserManager:
 
   def __parse_xml__(self, parser=None, data=None):
 
-    if not data or not parser:
+    if data is None or parser is None:
         logger.debug('No data or parser found')
         return
     logger.debug("will parse %s with xml" % parser['command'])

--- a/tests/unit/test_host_manager.py
+++ b/tests/unit/test_host_manager.py
@@ -66,6 +66,21 @@ commands_1 = {
   },
 }
 
+commands_2 = {
+  'test1_commands': {
+    'netconf':[ 'show version' ],
+    'tags': ['lab']
+  },
+  'test2_commands': {
+    'netconf':[ 'show test3' ],
+    'tags': ['lab-cmd']
+  },
+  'test4_commands': {
+    'netconf':[ 'show test4' ],
+    'tags': ['LAB-CMD']
+  }
+}
+
 class Test_Validate_Main_Block(unittest.TestCase):
  
   def test_import_host_manager(self):
@@ -125,6 +140,16 @@ class Test_Validate_Main_Block(unittest.TestCase):
       cmds = hm.get_target_commands('switch1',tags=['5m'])
       self.assertEqual(cmds[0]['commands'], 
                       ['show test3'])
+
+      ### Test with dash in tags
+      hm_b = HostManager( credentials=cred_pwd_01,
+                        commands=commands_2 )
+      hm_b.update_hosts(inventory_2)
+    
+      cmds_b = hm_b.get_target_commands('router1',tags=['lab'])
+      self.assertEqual(cmds_b[0]['commands'], 
+                      ['show version'])
+
 
   def test_get_credentials_default_port(self):
 


### PR DESCRIPTION
Currently the host manager is doing a simple regex match on the tag but it's not checking for the start or the end of the line so a small tag can match all tags that includes itself.