### PR TITLE
Add cpu fix for newer code for f5 parser

### DIFF
--- a/parsers/f5-cpu.yaml
+++ b/parsers/f5-cpu.yaml
@@ -12,3 +12,5 @@ parser:
             sub-matches:
                 - jmespath: entries.usageRatio.value
                   variable-name: cpu_usage
+                - jmespath: entries.fiveSecAvgRatio.value
+                  variable-name: cpu_usage_fiveSec


### PR DESCRIPTION
newer code doesnt return the usageRatio field any more. (thanks F5 you POS ). This adds the relevant field for the newer code