### PR TITLE
Bugfix in parser code

### DIFF
--- a/lib/metric_collector/f5_rest_collector.py
+++ b/lib/metric_collector/f5_rest_collector.py
@@ -81,6 +81,8 @@ class F5Collector(object):
         # find the command/query to execute
         parser = self.parsers.get_parser_for(command)
         raw_data = self.execute_query(parser['data']['parser']['query'])
+        if not raw_data:
+            return None
         datapoints = self.parsers.parse(command, raw_data)
 
         if datapoints is not None:

--- a/lib/metric_collector/netconf_collector.py
+++ b/lib/metric_collector/netconf_collector.py
@@ -137,7 +137,7 @@ class NetconfCollector():
     except RpcError as err:
       rpc_error = err.__repr__()
       logger.error("Error found on <%s> executing command: %s, error: %s:", self.hostname, command ,rpc_error)
-      return False
+      return None
 
     return command_result
 
@@ -146,6 +146,8 @@ class NetconfCollector():
     # find the command to execute from the parser directly
     parser = self.parsers.get_parser_for(command)
     data = self.execute_command(parser['data']['parser']['command'])
+    if not data:
+        return None
     if parser['data']['parser']['type'] == 'textfsm':
         data = etree.tostring(data)
     datapoints = self.parsers.parse(input=command, data=data)


### PR DESCRIPTION
some commands fail and the execution was returning a FAlse instead of a None, causing the code in the parser manager to crash because bool wasnt being evaluated as a None.