### PR TITLE
Fix status list for show bgp neighbor

### DIFF
--- a/parsers/show-bgp-neighbor.parser.yaml
+++ b/parsers/show-bgp-neighbor.parser.yaml
@@ -27,6 +27,7 @@ parser:
             -   xpath: ./peer-state
                 variable-name: status
                 enumerate:
-                  Establ: 0
+                  Established: 0
                   Active: 1
                   Idle: 2
+                  Connect: 3


### PR DESCRIPTION
I noticed that the status enum list for `show bgp neighbor` was not good.
