### PR TITLE
Fix issue with Enum for xml returning 0

### DIFF
--- a/lib/metric_collector/parser_manager.py
+++ b/lib/metric_collector/parser_manager.py
@@ -357,7 +357,7 @@ class ParserManager:
                     
                     if 'enumerate' in sub_match:
                       enum_match = False
-                      for enum_item in sub_match['enumerate']:
+                      for enum_item in sub_match['enumerate'].keys():
                         if value_tmp == enum_item:
                           enum_match = True
                           value_tmp = sub_match['enumerate'][enum_item]
@@ -367,7 +367,7 @@ class ParserManager:
                       elif not enum_match:
                         value_tmp = 0
 
-                    if value_tmp and key_tmp not in data_structure['fields']:
+                    if key_tmp not in data_structure['fields']:
                       if not self.is_valid_field(value_tmp):
                         continue
                       data_structure['fields'][key_tmp] = value_tmp

--- a/tests/unit/input/21_xml_enum_parser/parsers/show-bgp-neighbor.parser.yaml
+++ b/tests/unit/input/21_xml_enum_parser/parsers/show-bgp-neighbor.parser.yaml
@@ -1,0 +1,23 @@
+parser:
+    measurement: jnpr_bgp_neighbor
+    command: show bgp neighbor
+    type: xml
+    matches:
+    -   type: multi-value
+        method: xpath
+        xpath: //bgp-information/bgp-peer
+        loop:
+            peer-id: ./peer-id
+            peer-as: ./peer-as
+            peer-state: ./peer-state
+            peer-group: ./peer-group
+            sub-matches:
+            -   xpath: ./flap-count
+                variable-name: flap-count
+            -   xpath: ./peer-state
+                variable-name: status
+                enumerate:
+                  Established: 0
+                  Active: 1
+                  Idle: 2
+                  Connect: 3

--- a/tests/unit/input/21_xml_enum_parser/rpc-reply/show_bgp_neighbor/command.xml
+++ b/tests/unit/input/21_xml_enum_parser/rpc-reply/show_bgp_neighbor/command.xml
@@ -1,0 +1,173 @@
+<rpc-reply >
+    <bgp-information >
+        <bgp-peer >
+            <peer-address>10.20.192.0+179</peer-address>
+            <peer-as>65003</peer-as>
+            <local-address>10.20.192.1+53908</local-address>
+            <local-as>65002</local-as>
+            <peer-type>External</peer-type>
+            <peer-state>Established</peer-state>
+            <peer-flags>Sync RSync</peer-flags>
+            <last-state>EstabSync</last-state>
+            <last-event>RecvKeepAlive</last-event>
+            <last-error>Cease</last-error>
+            <bgp-option-information >
+                <export-policy>
+                    POLICY-OUT
+                </export-policy>
+                <bgp-options>Preference LocalAddress PeerAS Multipath LocalAS Refresh</bgp-options>
+                <bgp-options2>MultipathAs BfdEnabled</bgp-options2>
+                <bgp-options-extended></bgp-options-extended>
+                <local-address>10.20.192.1</local-address>
+                <holdtime>90</holdtime>
+                <preference>170</preference>
+                <local-as>65002</local-as>
+                <local-system-as>0</local-system-as>
+            </bgp-option-information>
+            <flap-count>13</flap-count>
+            <last-flap-event>Stop</last-flap-event>
+            <bgp-error>
+                <name>Cease</name>
+                <send-count>2</send-count>
+                <receive-count>2</receive-count>
+            </bgp-error>
+            <peer-id>10.20.250.251</peer-id>
+            <local-id>10.20.250.1</local-id>
+            <active-holdtime>90</active-holdtime>
+            <keepalive-interval>30</keepalive-interval>
+            <group-index>0</group-index>
+            <peer-index>0</peer-index>
+            <bgp-bfd>
+                <bfd-configuration-state>enabled</bfd-configuration-state>
+                <bfd-operational-state>up</bfd-operational-state>
+            </bgp-bfd>
+            <local-interface-name>et-0/0/52.0</local-interface-name>
+            <local-interface-index>613</local-interface-index>
+            <peer-restart-nlri-configured>inet-unicast</peer-restart-nlri-configured>
+            <nlri-type-peer>inet-unicast</nlri-type-peer>
+            <nlri-type-session>inet-unicast</nlri-type-session>
+            <peer-refresh-capability>2</peer-refresh-capability>
+            <peer-stale-route-time-configured>300</peer-stale-route-time-configured>
+            <peer-no-restart/>
+            <peer-restart-nlri-negotiated>inet-unicast</peer-restart-nlri-negotiated>
+            <peer-end-of-rib-received>inet-unicast</peer-end-of-rib-received>
+            <peer-end-of-rib-sent>inet-unicast</peer-end-of-rib-sent>
+            <peer-end-of-rib-scheduled></peer-end-of-rib-scheduled>
+            <peer-4byte-as-capability-advertised>65003</peer-4byte-as-capability-advertised>
+            <peer-addpath-not-supported/>
+            <bgp-rib >
+                <name>inet.0</name>
+                <rib-bit>10000</rib-bit>
+                <bgp-rib-state>BGP restart is complete</bgp-rib-state>
+                <vpn-rib-state>VPN restart is complete</vpn-rib-state>
+                <send-state>in sync</send-state>
+                <active-prefix-count>582</active-prefix-count>
+                <received-prefix-count>586</received-prefix-count>
+                <accepted-prefix-count>586</accepted-prefix-count>
+                <suppressed-prefix-count>0</suppressed-prefix-count>
+                <advertised-prefix-count>3</advertised-prefix-count>
+            </bgp-rib>
+            <last-received>18</last-received>
+            <last-sent>13</last-sent>
+            <last-checked>42</last-checked>
+            <input-messages>516107</input-messages>
+            <input-updates>181226</input-updates>
+            <input-refreshes>0</input-refreshes>
+            <input-octets>15406361</input-octets>
+            <output-messages>355874</output-messages>
+            <output-updates>1</output-updates>
+            <output-refreshes>0</output-refreshes>
+            <output-octets>6761700</output-octets>
+            <bgp-output-queue>
+                <number>0</number>
+                <count>0</count>
+            </bgp-output-queue>
+        </bgp-peer>
+        <bgp-peer >
+            <peer-address>10.20.193.0+179</peer-address>
+            <peer-as>65001</peer-as>
+            <local-address>10.20.193.1+64961</local-address>
+            <local-as>65002</local-as>
+            <peer-type>External</peer-type>
+            <peer-state>Idle</peer-state>
+            <peer-flags>Sync RSync</peer-flags>
+            <last-state>EstabSync</last-state>
+            <last-event>RecvKeepAlive</last-event>
+            <last-error>Cease</last-error>
+            <bgp-option-information >
+                <export-policy>
+                    POLICY-OUT
+                </export-policy>
+                <bgp-options>Preference LocalAddress PeerAS Multipath LocalAS Refresh</bgp-options>
+                <bgp-options2>MultipathAs BfdEnabled</bgp-options2>
+                <bgp-options-extended></bgp-options-extended>
+                <local-address>10.20.193.1</local-address>
+                <holdtime>90</holdtime>
+                <preference>170</preference>
+                <local-as>65002</local-as>
+                <local-system-as>0</local-system-as>
+            </bgp-option-information>
+            <flap-count>4</flap-count>
+            <last-flap-event>Stop</last-flap-event>
+            <bgp-error>
+                <name>Cease</name>
+                <send-count>3</send-count>
+                <receive-count>1</receive-count>
+            </bgp-error>
+            <peer-id>10.20.250.252</peer-id>
+            <local-id>10.20.250.1</local-id>
+            <active-holdtime>90</active-holdtime>
+            <keepalive-interval>30</keepalive-interval>
+            <group-index>0</group-index>
+            <peer-index>1</peer-index>
+            <bgp-bfd>
+                <bfd-configuration-state>enabled</bfd-configuration-state>
+                <bfd-operational-state>up</bfd-operational-state>
+            </bgp-bfd>
+            <local-interface-name>et-0/0/52.0</local-interface-name>
+            <local-interface-index>819</local-interface-index>
+            <peer-restart-nlri-configured>inet-unicast</peer-restart-nlri-configured>
+            <nlri-type-peer>inet-unicast</nlri-type-peer>
+            <nlri-type-session>inet-unicast</nlri-type-session>
+            <peer-refresh-capability>2</peer-refresh-capability>
+            <peer-stale-route-time-configured>300</peer-stale-route-time-configured>
+            <peer-no-restart/>
+            <peer-restart-nlri-negotiated>inet-unicast</peer-restart-nlri-negotiated>
+            <peer-end-of-rib-received>inet-unicast</peer-end-of-rib-received>
+            <peer-end-of-rib-sent>inet-unicast</peer-end-of-rib-sent>
+            <peer-end-of-rib-scheduled></peer-end-of-rib-scheduled>
+            <peer-4byte-as-capability-advertised>65001</peer-4byte-as-capability-advertised>
+            <peer-addpath-not-supported/>
+            <bgp-rib >
+                <name>inet.0</name>
+                <rib-bit>10000</rib-bit>
+                <bgp-rib-state>BGP restart is complete</bgp-rib-state>
+                <vpn-rib-state>VPN restart is complete</vpn-rib-state>
+                <send-state>in sync</send-state>
+                <active-prefix-count>581</active-prefix-count>
+                <received-prefix-count>586</received-prefix-count>
+                <accepted-prefix-count>586</accepted-prefix-count>
+                <suppressed-prefix-count>0</suppressed-prefix-count>
+                <advertised-prefix-count>3</advertised-prefix-count>
+            </bgp-rib>
+            <last-received>10</last-received>
+            <last-sent>18</last-sent>
+            <last-checked>63</last-checked>
+            <input-messages>513605</input-messages>
+            <input-updates>178730</input-updates>
+            <input-refreshes>0</input-refreshes>
+            <input-octets>15520812</input-octets>
+            <output-messages>355861</output-messages>
+            <output-updates>1</output-updates>
+            <output-refreshes>0</output-refreshes>
+            <output-octets>6761453</output-octets>
+            <bgp-output-queue>
+                <number>0</number>
+                <count>0</count>
+            </bgp-output-queue>
+        </bgp-peer>
+    </bgp-information>
+    <cli>
+        <banner>{master:0}</banner>
+    </cli>
+</rpc-reply>

--- a/tests/unit/test_parser_manager.py
+++ b/tests/unit/test_parser_manager.py
@@ -115,6 +115,33 @@ class Test_Validate_Main_Block(unittest.TestCase):
 
     self.assertTrue( len(data) == 2 )
 
+  def test_parse_valid_xml_enum(self):
+    test_dir = here+'/input/21_xml_enum_parser'
+
+    pm = parser_manager.ParserManager( parser_dirs=[test_dir + "/parsers"], default_parser_dir=False )
+
+    ## Read XML content
+    xml_data = open( test_dir + "/rpc-reply/show_bgp_neighbor/command.xml").read()
+    xml_etree = etree.fromstring(xml_data)
+
+    expected_dict_0 = {
+        'fields': {'flap-count': '13', 'status': 0},
+        'measurement': None,
+        'tags': {'peer-id': '10.20.250.251', 'peer-as': '65003', 'peer-state': 'Established'}, 
+    }
+    expected_dict_1 = {
+        'fields': {'flap-count': '4', 'status': 2},
+        'measurement': None,
+        'tags': {'peer-id': '10.20.250.252', 'peer-as': '65001', 'peer-state': 'Idle'}
+    }
+  
+    data = list(pm.parse( input="show-bgp-neighbor.parser.yaml", data=xml_etree))
+
+    self.assertDictEqual( expected_dict_0, data[0] )
+    self.assertDictEqual( expected_dict_1, data[1] )
+
+    self.assertTrue( len(data) == 2 )
+
   # def test_parse_valid_regex(self):
   #   test_dir = here+'/input/21_regex_parser'
 


### PR DESCRIPTION
I noticed that enum value in XML parser returning `0` were not making to the final measurement.

I tracked it down to this test where we are doing `if value_tmp`, this test will return `False` when value_tmp == 0.
Since we have the test `is_valid_field` next I think we can remove the first test to ensure the value of the field is valid

```python
if value_tmp and key_tmp not in data_structure['fields']:	                    
       if not self.is_valid_field(value_tmp):	                     
           continue	                  
       data_structure['fields'][key_tmp] = value_tmp
```