### PR TITLE
Fix scheduling on hosts refresh

### DIFF
--- a/lib/metric_collector/cli.py
+++ b/lib/metric_collector/cli.py
@@ -60,7 +60,7 @@ def shard_host_list(shard_id, shard_size, hosts):
     return hosts
 
 
-def select_hosts(hosts_file, tag_list, sharding, sharding_offset, scheduler=None, refresh_interval=None):
+def select_hosts(hosts_file, tag_list, sharding, sharding_offset, scheduler=None, refresh_interval=None, refresh=False):
     """
     Parse a host file or pull hosts from dynamic inventory , and add it to the scheduler periodically
     """
@@ -82,11 +82,11 @@ def select_hosts(hosts_file, tag_list, sharding, sharding_offset, scheduler=None
         hosts = shard_host_list(shard_id, shard_size, hosts)
 
     if scheduler:
-        scheduler.add_hosts(hosts, host_tags=tag_list)
+        scheduler.add_hosts(hosts, host_tags=tag_list, refresh=refresh)
         t = threading.Timer(
             refresh_interval, select_hosts,
             args=(hosts_file, tag_list, sharding, sharding_offset),
-            kwargs={'scheduler': scheduler, 'refresh_interval': refresh_interval},
+            kwargs={'scheduler': scheduler, 'refresh_interval': refresh_interval, 'refresh': True},
         )
         t.setDaemon(True)
         t.start()

--- a/lib/metric_collector/utils.py
+++ b/lib/metric_collector/utils.py
@@ -1,6 +1,6 @@
 import logging
 import requests
-from itertools import chain, islice
+from itertools import chain, islice, cycle
 
 logger = logging.getLogger('collector')
 
@@ -68,3 +68,12 @@ def chunks(iterable, size=1000):
     iterator = iter(iterable)
     for first in iterator:
         yield chain([first], islice(iterator, size - 1))
+
+
+class Cycle(cycle):
+    """ wraps itertools.cycle """
+    def __init__(self, iterable):
+        self.len = len(iterable)
+        cycle.__init__(iterable)
+    def __len__(self):
+        return self.len


### PR DESCRIPTION
there was a bug in the scheduling code that would zeroize the hosts for a worker thread when an inventory refresh happened. This fixes the issue by keeping a track of the threads already started for an interval.