### PR TITLE
Add option to disable facts collection

### DIFF
--- a/lib/metric_collector/cli.py
+++ b/lib/metric_collector/cli.py
@@ -207,6 +207,8 @@ def main():
     full_parser.add_argument("--commands", default="commands.yaml", help="Commands file in Yaml")
     full_parser.add_argument("--credentials", default="credentials.yaml", help="Credentials file in Yaml")
 
+    full_parser.add_argument("--no-facts", action='store_false', help="Disable facts collection on device (remove version and product name in results)")
+    
     full_parser.add_argument("--output-format", default="influxdb", help="Format of the output")
     full_parser.add_argument("--output-type", default="stdout", choices=['stdout', 'http'], help="Type of output")
     full_parser.add_argument("--output-addr", default="http://localhost:8186/write", help="Addr information for output action")
@@ -352,7 +354,12 @@ def main():
         commands=general_commands
     )
     hosts_manager.update_hosts(hosts_conf)
-    coll = collector.Collector(hosts_manager, parsers_manager, dynamic_args['output_type'], dynamic_args['output_addr'])
+    coll = collector.Collector(
+            hosts_manager=hosts_manager, 
+            parser_manager=parsers_manager, 
+            output_type=dynamic_args['output_type'], 
+            output_addr=dynamic_args['output_addr'],
+            collect_facts=dynamic_args.get('no_facts', True))
     target_hosts = hosts_manager.get_target_hosts(tags=tag_list)
 
     if use_threads:

--- a/lib/metric_collector/collector.py
+++ b/lib/metric_collector/collector.py
@@ -12,11 +12,12 @@ global_measurement_prefix = 'metric_collector'
 
 class Collector:
 
-    def __init__(self, hosts_manager, parser_manager, output_type, output_addr):
+    def __init__(self, hosts_manager, parser_manager, output_type, output_addr, collect_facts=True):
         self.hosts_manager = hosts_manager
         self.parser_manager = parser_manager
         self.output_type = output_type
         self.output_addr = output_addr
+        self.collect_facts = collect_facts
 
     def collect(self, worker_name, hosts=None, host_cmds=None, cmd_tags=None):
         if not hosts and not host_cmds:
@@ -46,7 +47,7 @@ class Collector:
             if device_type == 'juniper':
                 dev = netconf_collector.NetconfCollector(
                         host=host, address=host_address, credential=credential,
-                        parsers=self.parser_manager, context=host_context)
+                        parsers=self.parser_manager, context=host_context, collect_facts=self.collect_facts)
             elif device_type == 'f5':
                 dev = f5_rest_collector.F5Collector(
                     host=host, address=host_address, credential=credential,

--- a/lib/metric_collector/netconf_collector.py
+++ b/lib/metric_collector/netconf_collector.py
@@ -14,12 +14,24 @@ pp = pprint.PrettyPrinter(indent=4)
 
 class NetconfCollector():
 
-  def __init__(self, host=None, address=None, credential={}, test=False, timeout=15, retry=3, use_hostname=True, parsers=None, context=None):
+  def __init__(self, 
+        host=None, 
+        address=None, 
+        credential={}, 
+        test=False, 
+        timeout=15, 
+        retry=3, 
+        use_hostname=True, 
+        parsers=None, 
+        context=None,
+        collect_facts=True):
+
     self.__is_connected = False
     self.__is_test = test
     self.__use_hostname = use_hostname
     self.__timeout = timeout
     self.__retry = retry
+    self.__collect_facts = collect_facts
 
     self.host = address
     self.hostname = host
@@ -106,26 +118,29 @@ class NetconfCollector():
     if not self.__is_connected:
       return
 
-    # Collect Facts about the device
-    logger.info('[%s]: Collection Facts on device', self.hostname)
-    self.pyez.facts_refresh()
+    # Collect Facts about the device (if enabled)
+    if self.__collect_facts:
+      logger.info('[%s]: Collection Facts on device', self.hostname)
+      self.pyez.facts_refresh()
 
-    if self.pyez.facts['version']:
-      self.facts['version'] = self.pyez.facts['version']
-    else:
-      self.facts['version'] = 'unknown'
+      if self.pyez.facts['version']:
+        self.facts['version'] = self.pyez.facts['version']
+      else:
+        self.facts['version'] = 'unknown'
 
-    self.facts['product-model'] = self.pyez.facts['model']
+      self.facts['product-model'] = self.pyez.facts['model']
 
-    ## Based on parameter defined in config file
-    if self.__use_hostname and self.pyez.facts['hostname'] != self.hostname:
-      hostname = self.pyez.facts['hostname']
-      logger.info('[%s]: Host will now be referenced as : %s', self.hostname, hostname)
-      self.hostname = hostname
-    else:
-      logger.info('[%s]: Host will be referenced as : %s', self.hostname, self.hostname)
+      ## Based on parameter defined in config file
+      if self.__use_hostname and self.pyez.facts['hostname'] != self.hostname:
+        hostname = self.pyez.facts['hostname']
+        logger.info('[%s]: Host will now be referenced as : %s', self.hostname, hostname)
+        self.hostname = hostname
+      else:
+        logger.info('[%s]: Host will be referenced as : %s', self.hostname, self.hostname)
+
 
     self.facts['device']=self.hostname
+
     return True
 
   def execute_command(self,command=None):


### PR DESCRIPTION
I notice that the facts collection can generate a lot of query on the device and on some of the low end devices, it's triggering some issues related to CPU

Since the collector is not 100% dependent on the facts, I added an option to disable them.
the main impact is that it will remove 2 tags from the results (`version` and `product-model` ) but everything else is working fine

```
metric-collector --commands commands.yaml --credentials cred.yaml --hosts hosts.yaml -s --output-type=stdout --no-facts
```

