### PR TITLE
Add new parsers for SRX devices

### DIFF
--- a/lib/metric_collector/cli.py
+++ b/lib/metric_collector/cli.py
@@ -127,7 +127,7 @@ def import_inventory(hosts_file, retry=3, retry_internal=5):
 
         try:
             with open(hosts_file) as f:
-                hosts = yaml.load(f)
+                hosts = yaml.full_load(f)
             is_yaml = True
         except Exception as e:
             logger.debug('Error importing host file in yaml: %s > %s [%s/%s]' % (hosts_file, e, i, retry ))
@@ -289,7 +289,7 @@ def main():
     logger.info('Importing credentials file: %s ',credentials_yaml_file)
     try:
         with open(credentials_yaml_file) as f:
-            credentials = yaml.load(f)
+            credentials = yaml.full_load(f)
     except Exception as e:
         logger.error('Error importing credentials file: %s', credentials_yaml_file)
         sys.exit(0)
@@ -308,7 +308,7 @@ def main():
     logger.info('Importing commands file: %s ',commands_yaml_file)
     with open(commands_yaml_file) as f:
         try:
-            for document in yaml.load_all(f):
+            for document in yaml.load_all(f, yaml.FullLoader):
                 commands.append(document)
         except Exception as e:
             logger.error('Error importing commands file: %s, %s', commands_yaml_file, str(e))

--- a/lib/metric_collector/parser_manager.py
+++ b/lib/metric_collector/parser_manager.py
@@ -66,7 +66,7 @@ class ParserManager:
 
         try:
           with open(full_junos_parsers_file) as f:
-            parser["data"] = yaml.load(f)
+            parser["data"] = yaml.full_load(f)
         except Exception as e:
           logger.error('Error importing junos parser, yaml non valid: %s. %s', junos_parsers_file, str(e))
           continue

--- a/parsers/show-security-flow-session-summary.parser.1.yaml
+++ b/parsers/show-security-flow-session-summary.parser.1.yaml
@@ -1,0 +1,40 @@
+parser:
+    command: show security flow session summary
+    measurement: jnpr_flow_session_summary
+    type: xml
+    matches:
+    -   type: multi-value
+        method: xpath
+        xpath: //flow-session-summary-information
+        loop:
+            pool_name: ./resource-usage-pool-name
+            fpc-id: ./slot
+            sub-matches:
+            -   xpath: ./active-unicast-sessions
+                variable-name: active_unicast_sessions
+
+            -   xpath: ./active-multicast-sessions
+                variable-name: active_multicast_sessions
+
+            -   xpath: ./failed-sessions
+                variable-name: failed_sessions
+
+            -   xpath: ./active-sessions
+                variable-name: active_sessions
+
+            -   xpath: ./active-session-valid
+                variable-name: active_session_valid
+
+            -   xpath: ./active-session-pending
+                variable-name: active_session_pending
+
+            -   xpath: ./active-session-invalidated
+                variable-name: active_session_invalidated
+
+            -   xpath: ./active-session-other
+                variable-name: active_session_other
+
+            -   xpath: ./max-sessions
+                variable-name: max_sessions
+
+

--- a/parsers/show-security-flow-statistics.parser.yaml
+++ b/parsers/show-security-flow-statistics.parser.yaml
@@ -1,0 +1,29 @@
+parser:
+    command: show security flow statistics
+    measurement: jnpr_flow_statistics
+    type: xml
+    matches:
+    -   type: multi-value
+        method: xpath
+        xpath: //flow-statistics-all
+        loop:
+            sub-matches:
+            -   xpath: ./flow-session-count-valid
+                variable-name: current_session_total
+
+            -   xpath: ./flow-pkt-count-fwd
+                variable-name: packet_forwarded_total
+
+            -   xpath: ./flow-pkt-count-drop
+                variable-name: packet_drop_total
+
+            -   xpath: ./flow-frag-count-fwd
+                variable-name: packet_fragment_total
+
+            -   xpath: ./tunnel-frag-gen-pre
+                variable-name: packet_pre_fragment_total
+
+            -   xpath: ./tunnel-frag-gen-post
+                variable-name: packet_post_fragment_total
+
+

--- a/parsers/show-security-monitoring.parser.yaml
+++ b/parsers/show-security-monitoring.parser.yaml
@@ -1,0 +1,29 @@
+parser:
+    command: show security monitoring
+    measurement: jnpr_security_monitoring
+    type: xml
+    matches:
+    -   type: multi-value
+        method: xpath
+        xpath: //performance-summary-information/performance-summary-statistics
+        loop:
+            fpc-id: ./fpc-number
+            pic-id: ./pic-number
+            sub-matches:
+            -   xpath: ./spu-cpu-utilization
+                variable-name: cpu_utilization
+
+            -   xpath: ./spu-memory-utilization
+                variable-name: memory_utilization
+
+            -   xpath: ./spu-current-flow-session
+                variable-name: flow_current_session
+
+            -   xpath: ./spu-max-flow-session
+                variable-name: flow_maximum_session
+
+            -   xpath: ./spu-current-cp-session
+                variable-name: cp_current_session
+
+            -   xpath: ./spu-max-cp-session
+                variable-name: cp_maximum_session

--- a/parsers/show-security-policies-hit-count.parser.yaml
+++ b/parsers/show-security-policies-hit-count.parser.yaml
@@ -1,0 +1,16 @@
+parser:
+    command: show security policies hit-count
+    measurement: jnpr_security_policy_hit_count
+    type: xml
+    matches:
+    -   type: multi-value
+        method: xpath
+        xpath: //policy-hit-count/policy-hit-count-entry
+        loop:
+            system: ./../logical-system-name
+            zone_from: ./policy-hit-count-from-zone
+            zone_to: ./policy-hit-count-to-zone
+            policy: ./policy-hit-count-policy-name
+            sub-matches:
+            -   xpath: ./policy-hit-count-count
+                variable-name: value


### PR DESCRIPTION
Add 4 new parsers to collect FW statistics on a SRX device
### show security flow session summary
Global sessions statistics
- active_unicast_sessions
- active_multicast_sessions
- failed_sessions
- active_sessions
- active_session_valid
- active_session_pending
- active_session_invalidated
- active_session_other
- max_sessions

### show security flow statistics
Global Flow / Packets statistics
- current_session_total
- packet_forwarded_total
- packet_drop_total
- packet_fragment_total
- packet_pre_fragment_total
- packet_post_fragment_total

### show security policies hit-count
Hit count per `source_zone/destination_zone/policy`

### show security monitoring
- SPU engine monitoring
- cpu_utilization
- memory_utilization
- flow_current_session
- flow_maximum_session
- cp_current_session
- cp_maximum_session

This PR also include a fix for the Yaml Loader to remove a warning message related to some deprecated function.