### PR TITLE
fix timeouts

### DIFF
--- a/lib/metric_collector/cli.py
+++ b/lib/metric_collector/cli.py
@@ -199,8 +199,7 @@ def main():
     full_parser.add_argument("--sharding-offset", default=True, help="Define an offset needs to be applied to the shard_id")
 
     full_parser.add_argument("--parserdir", default="parsers", help="Directory where to find parsers")
-    full_parser.add_argument("--connect-timeout", default=15, help="Timeout for collector device connect")
-    full_parser.add_argument("--command-timeout", default=30, help="Timeout for collector device rpc calls")
+    full_parser.add_argument("--collector-timeout", default=15, help="Timeout for collector device rpc/rest calls")
     full_parser.add_argument("--retry", default=5, help="Max retry")
 
     full_parser.add_argument("--host", default=None, help="Host DNS or IP")
@@ -328,8 +327,7 @@ def main():
             dynamic_args['output_type'], dynamic_args['output_addr'],
             max_worker_threads=max_worker_threads,
             use_threads=use_threads, num_threads_per_worker=max_collector_threads,
-            connect_timeout=dynamic_args['connect_timeout'],
-            command_timeout=dynamic_args['command_timeout']
+            collector_timeout=dynamic_args['collector_timeout']
         )
         hri = dynamic_args.get('hosts_refresh_interval', 6 * 60 * 60)
         select_hosts(
@@ -357,8 +355,7 @@ def main():
             output_type=dynamic_args['output_type'], 
             output_addr=dynamic_args['output_addr'],
             collect_facts=dynamic_args.get('no_facts', True),
-            connect_timeout=dynamic_args['connect_timeout'],
-            command_timeout=dynamic_args['command_timeout']
+            timeout=dynamic_args['collector_timeout']
     )
     target_hosts = hosts_manager.get_target_hosts(tags=tag_list)
 

--- a/lib/metric_collector/collector.py
+++ b/lib/metric_collector/collector.py
@@ -13,14 +13,13 @@ global_measurement_prefix = 'metric_collector'
 class Collector:
 
     def __init__(self, hosts_manager, parser_manager, output_type, output_addr,
-            collect_facts=True, connect_timeout=15, command_timeout=30):
+            collect_facts=True, timeout=30):
         self.hosts_manager = hosts_manager
         self.parser_manager = parser_manager
         self.output_type = output_type
         self.output_addr = output_addr
         self.collect_facts = collect_facts
-        self.connect_timeout = connect_timeout
-        self.command_timeout = command_timeout
+        self.timeout = timeout
 
     def collect(self, worker_name, hosts=None, host_cmds=None, cmd_tags=None):
         if not hosts and not host_cmds:
@@ -50,11 +49,11 @@ class Collector:
             if device_type == 'juniper':
                 dev = netconf_collector.NetconfCollector(
                         host=host, address=host_address, credential=credential,
-                        parsers=self.parser_manager, context=host_context, collect_facts=self.collect_facts, timeout=self.connect_timeout)
+                        parsers=self.parser_manager, context=host_context, collect_facts=self.collect_facts, timeout=self.timeout)
             elif device_type == 'f5':
                 dev = f5_rest_collector.F5Collector(
                     host=host, address=host_address, credential=credential,
-                    parsers=self.parser_manager, context=host_context, timeout=self.connect_timeout)
+                    parsers=self.parser_manager, context=host_context, timeout=self.timeout)
             dev.connect()
 
             if dev.is_connected():
@@ -76,7 +75,7 @@ class Collector:
                 for command in target_commands:
                     try:
                         logger.info('[%s] Collecting > %s' % (host,command))
-                        data = dev.collect(command, timeout=self.command_timeout)  # returns a generator
+                        data = dev.collect(command)  # returns a generator
                         if data:
                             values.append(data)
                             cmd_successful += 1

--- a/lib/metric_collector/f5_rest_collector.py
+++ b/lib/metric_collector/f5_rest_collector.py
@@ -64,26 +64,25 @@ class F5Collector(object):
 
         # TODO(Mayuresh) Collect any other relevant facts here
 
-    def execute_query(self, query, timeout=None):
+    def execute_query(self, query):
 
         base_url = 'https://{}/'.format(self.host)
         try:
             query = base_url + query
             logger.debug('[%s]: execute : %s', self.hostname, query)
-            timeout = timeout or self.__timeout
-            result = self.mgmt.icrs.get(query, timeout=timeout)
+            result = self.mgmt.icrs.get(query)
             return result.json()
         except Exception as ex:
             logger.error('Failed to execute query: %s on %s: %s', query, self.hostname, str(ex))
             return
 
-    def collect(self, command, timeout=None):
+    def collect(self, command):
 
         # find the command/query to execute
         logger.debug('[%s]: parsing : %s', self.hostname, command)
         parser = self.parsers.get_parser_for(command)
         try:
-            raw_data = self.execute_query(parser['data']['parser']['query'], timeout=timeout)
+            raw_data = self.execute_query(parser['data']['parser']['query'])
         except TypeError as e:
             logger.error('Parser returned no data. Message: {}'.format(e))
             raw_data = None

--- a/lib/metric_collector/netconf_collector.py
+++ b/lib/metric_collector/netconf_collector.py
@@ -143,12 +143,10 @@ class NetconfCollector():
 
     return True
 
-  def execute_command(self,command=None, timeout=None):
+  def execute_command(self,command=None):
 
     try:
       logger.debug('[%s]: execute : %s', self.hostname, command)
-      if timeout:
-        self.pyez.timeout = timeout
       # the data returned is already in etree format
       command_result = self.pyez.rpc.cli(command, format="xml")
     except RpcError as err:
@@ -158,11 +156,11 @@ class NetconfCollector():
 
     return command_result
 
-  def collect(self, command=None, timeout=None):
+  def collect(self, command=None):
 
     # find the command to execute from the parser directly
     parser = self.parsers.get_parser_for(command)
-    data = self.execute_command(parser['data']['parser']['command'], timeout=timeout)
+    data = self.execute_command(parser['data']['parser']['command'])
     
     if data is None:
         return None

--- a/lib/metric_collector/scheduler.py
+++ b/lib/metric_collector/scheduler.py
@@ -17,7 +17,7 @@ class Scheduler:
         self.host_mgr = host_manager.HostManager(credentials=creds_conf, commands=cmds_conf)
         self.parser_mgr = parser_manager.ParserManager(parser_dirs=parsers_dir)
         self.collector = collector.Collector(self.host_mgr, self.parser_mgr, output_type, output_addr,
-            collector_timeout=collector_timeout)
+            timeout=collector_timeout)
         self.max_worker_threads = max_worker_threads
         self.output_type = output_type
         self.output_addr = output_addr

--- a/lib/metric_collector/scheduler.py
+++ b/lib/metric_collector/scheduler.py
@@ -11,13 +11,13 @@ class Scheduler:
 
     def __init__(self, creds_conf, cmds_conf, parsers_dir, output_type, output_addr,
                  max_worker_threads=1, use_threads=True, num_threads_per_worker=10,
-                 connect_timeout=15, command_timeout=30):
+                 collector_timeout=30):
         self.workers = {}
         self.working = set()
         self.host_mgr = host_manager.HostManager(credentials=creds_conf, commands=cmds_conf)
         self.parser_mgr = parser_manager.ParserManager(parser_dirs=parsers_dir)
         self.collector = collector.Collector(self.host_mgr, self.parser_mgr, output_type, output_addr,
-            connect_timeout=connect_timeout, command_timeout=command_timeout)
+            collector_timeout=collector_timeout)
         self.max_worker_threads = max_worker_threads
         self.output_type = output_type
         self.output_addr = output_addr


### PR DESCRIPTION
the previous PR #63  added 2 timeouts. turns out the connect_timeout does nothing, so this removes that and only adds a single global collector_timeout which is the timeout for all rpc/rest calls.